### PR TITLE
[nettab] Support Pid= and Comment= as attributes

### DIFF
--- a/nettab/libs/python/nettab/basesc3.py
+++ b/nettab/libs/python/nettab/basesc3.py
@@ -12,6 +12,10 @@ class sc3(object):
             try:
                 if k == 'Comment':
                     # print('DEBUG: Adding comment', p)
+                    if p.startswith('Grant'):
+                        # 2020: These belong in DOI metadata, not here.
+                        continue
+
                     c = seiscomp.datamodel.Comment()
                     c.setText(p)
                     c.setId(str(commentNum))
@@ -23,9 +27,9 @@ class sc3(object):
                     # print('DEBUG: Adding Pid as comment', p)
                     c = seiscomp.datamodel.Comment()
                     (typ, val) = p.split(':', 1)
-                    s = '{"type":"%s","value":"%s"}' % (typ.upper(), val)
+                    s = '{"type":"%s", "value":"%s"}' % (typ.upper(), val)
                     c.setText(s)
-                    c.setId(str(commentNum))
+                    c.setId('FDSNXML:Identifier/' + str(commentNum))
                     commentNum += 1
                     obj.add(c)
                     continue

--- a/nettab/libs/python/nettab/test/testTab.py
+++ b/nettab/libs/python/nettab/test/testTab.py
@@ -13,6 +13,7 @@
 from __future__ import print_function
 
 from nettab.tab import Tab
+import json
 import os
 import sys
 import tempfile
@@ -238,7 +239,9 @@ Na: Foo=bar
         self._writeNewInvXML(sc3inv, outFile)
         self.assertTrue(os.path.exists(outFile))
 
-        # Further checks: that the file contains a network with PID. TODO
+        # Check that the file contains exactly one network comment
+        # which is a JSON string with PID.
+        # e.g. '{"type": "DOI", "value": "10.1234/xsdfa"}'
         (elem, ns) = xmlparse(outFile)
         for e in elem:
             for f in e:
@@ -246,7 +249,11 @@ Na: Foo=bar
                     g = f.findall(ns + 'comment')
                     self.assertTrue(len(g) == 1)
                     t = g[0].findall(ns + 'text')
-                    self.assertEqual(t[0].text, 'doi:10.1234/xyz')
+                    text = t[0].text
+                    j = json.loads(t[0].text)
+                    self.assertEqual(j['type'], 'DOI')
+                    self.assertEqual(j['value'], '10.1234/xyz')
+                    ### self.assertEqual(t[0].text, 'doi:10.1234/xyz')
 
     def test_10_network_comment(self):
         tabString = '''


### PR DESCRIPTION
Extend tab2inv and tabinvmodifier to support two new
network attributes (Na lines):

Na: Comment="This is commentary"
Na: Pid="doi:10.1234/xyz"

- 'Na: Pid="..."' sets a <Comment> in SC XML, but is rendered
  as <Identifier> in FDSN Station XML.

- 'Na: Comment="Grant..."' gets ignored.