### PR TITLE
[msrtsimul.py] better record exception handling?

### DIFF
--- a/utils/apps/msrtsimul.py
+++ b/utils/apps/msrtsimul.py
@@ -240,6 +240,8 @@ Check if SeedLink is running and configured for real-time playback.
         time_diff = None
         print("Starting msrtsimul at {}".format(datetime.datetime.utcnow()), file=sys.stderr)
         for rec in inp:
+            if rec.size != 512:
+                continue
             if time_diff is None:
                 ms = 1000000.0 * (rec.nsamp / rec.fsamp)
                 time_diff = datetime.datetime.utcnow() - rec.begin_time - \


### PR DESCRIPTION
A very small push request, only to avoid msrtsimul to crash when reaching an unexpected record, as it might happen with station name-based data dump including SOH or status channels... 