### PR TITLE
[nettab] Fix for Python3 compatibility

### DIFF
--- a/nettab/libs/python/nettab/convertUtils.py
+++ b/nettab/libs/python/nettab/convertUtils.py
@@ -31,7 +31,7 @@ def parseDate(val):
     try:
         return datetime.strptime(date, formats[len(date)])
     except Exception as e:
-        raise ValueError, "invalid date: " + date + str(e)
+        raise ValueError("invalid date: " + date + str(e))
 
 def formatDate(date):
     if not date:


### PR DESCRIPTION
Hello,

I had problems using tab2tab with Python 3. I got the following error message:
```python
File ...seiscomp/4.8.3/lib/python/nettab/convertUtils.py", line 34
    raise ValueError, "invalid date: " + date + str(e)
                    ^
SyntaxError: invalid syntax
```
It works for me If I change line 34 to :
```python
raise ValueError("invalid date: " + date + str(e)) 
```

Thank you,
Michael